### PR TITLE
Fix typo in install error message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ sudo chsh -s $(which zsh) $USER
 # Run stow
 echo '+ Creating symlinks'
 cd $DOTDIR && stow .
-[ $? -eq 1 ] && echo "Error: Remove the refereces and try again."
+[ $? -eq 1 ] && echo "Error: Remove the references and try again."
 
 # TODO: Locking file to don't install multiple times. 
 logging


### PR DESCRIPTION
## Summary
- fix typo in stow error message

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892d44bd1ac8322bf1a83b388ca65b4