### PR TITLE
Fix install script environment checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,24 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 set -u
 
 brew_install() {
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     eval $(/opt/homebrew/bin/brew shellenv)
-    BREW=(which brew)
+    BREW=$(which brew)
 }
 
 logging() {
     echo "$(date -u +'%Y-%m-%d:%H:%M:%S UTC') - Installed" >> install.log
-    touch $(date) > installed.lock
+    date -u > installed.lock
 }
 
 BREW="/opt/homebrew/bin/brew"
 DOTDIR="${HOME}/dotfiles"
 [ ! -f $DOTDIR/install.sh ] && git clone https://github.com/MrKoopaKiller/dotfiles.git $DOTDIR
 
-if [[ -f "$BREW" ]]; then brew_install; fi
+if [[ ! -f "$BREW" ]]; then brew_install; fi
 if [[ $(uname) == 'Darwin' ]]; then brew bundle install; fi
-if [[ $(uname) == 'linux' ]]; then xargs sudo apt-get -y install < ${DOTDIR}/aptfile; fi
+if [[ $(uname) == 'Linux' ]]; then xargs sudo apt-get -y install < ${DOTDIR}/aptfile; fi
 
 # Install vim-plug
 sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \


### PR DESCRIPTION
## Summary
- prevent unnecessary Homebrew reinstallation and correct Linux package detection
- clean up installation logging

## Testing
- `bash -n install.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892ce174d0c8322923353666c0ef8d9