### PR TITLE
Add Bats test for steampipe AWS config generator

### DIFF
--- a/bats
+++ b/bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Minimal bats runner for environments without bats-core
+file="$1"
+if [[ -z "$file" ]]; then
+  echo "usage: bats <file>" >&2
+  exit 1
+fi
+status=0
+tests=()
+current_func=""
+body=""
+pre=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ $line =~ ^@test[[:space:]]+\"([^\"]+)\"[[:space:]]*\{$ ]]; then
+    current_name=${BASH_REMATCH[1]}
+    current_func="test_${#tests[@]}"
+    tests+=("$current_func:::${current_name}")
+    body=""
+  elif [[ $line == "}" && -n "$current_func" ]]; then
+    printf -v func_def '%s() {\n%s\n}' "$current_func" "$body"
+    eval "$func_def"
+    current_func=""
+    elif [[ -n "$current_func" ]]; then
+      body+="$line"$'\n'
+    else
+      pre+="$line"$'\n'
+    fi
+  done < "$file"
+eval "$pre"
+for t in "${tests[@]}"; do
+  func=${t%%:::*}
+  name=${t#*:::}
+  echo -n "$name: "
+  if "$func"; then
+    echo "ok"
+  else
+    echo "fail"
+    status=1
+  fi
+done
+exit $status

--- a/tests/steampipe_aws_config_gen.bats
+++ b/tests/steampipe_aws_config_gen.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+run() {
+  output="$($@ 2>&1)"
+  status=$?
+}
+
+@test "generates connection blocks with hyphenated profile names converted to underscores" {
+  stub_dir=$(mktemp -d)
+  cat <<'STUB' > "$stub_dir/aws"
+#!/usr/bin/env bash
+echo default
+echo my-profile
+echo nohyphen
+STUB
+  chmod +x "$stub_dir/aws"
+  PATH="$stub_dir:$PATH" run ./scripts/steampipe_aws_config_gen.sh
+  [[ $status -eq 0 ]]
+  [[ "$output" == *'connection "my_profile"'* ]]
+  [[ "$output" == *'profile = "my_profile"'* ]]
+  [[ "$output" == *'connection "nohyphen"'* ]]
+  [[ "$output" == *'regions = ["us-east-*", "us-west-*", "eu-west-*","eu-central-1", "eu-north-1"]'* ]]
+}


### PR DESCRIPTION
## Summary
- add a minimal `bats` runner script
- test steampipe AWS config generator for proper profile and region output

## Testing
- `PATH="$PWD:$PATH" bats tests/steampipe_aws_config_gen.bats`


------
https://chatgpt.com/codex/tasks/task_e_6892d5fa8014832284553597acd02e8d